### PR TITLE
Enhance directory banning functionality to support multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Look no further, this code fixes that!
 5. Run the index script : `bun index.ts`
 6. Start Synology Drive again and enjoy
 
+## Ignoring additional directories
+
+By default, the script will ignore `node_modules` directory only. If you want to ignore additional directories, you can pass them as a command line argument:
+
+```sh
+bun index.ts --ignore=dist,build,customDir
+```
+
+This will always include `node_modules` and also will add `dist`, `build`, and `customDir` to the list of directories to ignore.
+
 # What does it do ?
 
 The script goes in the following directory : `~/Library/Application Support/SynologyDrive/SynologyDrive.app/Contents/Resources/conf`


### PR DESCRIPTION
hi, just a minor update to accept command-line arguments to the script in order to also ignore any desired folder name such as: `dist/` and `build/`, I'm a developer and personally don't even want to have those folders synced on my NAS, but maybe not all people have this requirement:

to do this simply add `--ignore=folder_name1,folder_name2` to the original command or simply run the plain `bun index.ts` if only want to ignore `node_modules/`

e.g.: 
```bash
$ bun index.ts --ignore=dist,build
Editing file : /Users/israelsantiago/Library/Application Support/SynologyDrive/SynologyDrive.app/Contents/Resources/conf/blacklist.filter
File backed-up successfully.
node_modules, dist, build have been successfully banned from Synology Drive.
Editing file : /Users/israelsantiago/Library/Application Support/SynologyDrive/SynologyDrive.app/Contents/Resources/conf/filter-v4150
File backed-up successfully.
node_modules, dist, build have been successfully banned from Synology Drive.
Operation completed successfully.
$
```