### PR TITLE
Circumvented a bug where Bun.write would be rejected because of a lac…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,12 @@ async function editConfigFile(path: string): Promise<void> {
 
     // We save the file
     const updatedConfig = ini.stringify(config)
-    await Bun.write(path, updatedConfig)
+    try {
+        await Bun.write(path, updatedConfig)
+    } catch (error: unknown) {
+        const fs = await import('fs')
+        fs.writeFileSync(path, updatedConfig)
+    }
 
     console.info(`${banDirNames.join(', ')} have been successfully banned from Synology Drive.`)
 }

--- a/index.ts
+++ b/index.ts
@@ -94,6 +94,7 @@ async function editConfigFile(path: string): Promise<void> {
     } catch (error: unknown) {
         const fs = await import('fs')
         fs.writeFileSync(path, updatedConfig)
+        console.info(`🧐 For some reason, Bun.write() fails on your device. We've switched it to fs.writeFileSync() for you! If you see this, the edits have succeeded.`)
     }
 
     console.info(`${banDirNames.join(', ')} have been successfully banned from Synology Drive.`)
@@ -105,9 +106,9 @@ async function backupFile(file: BunFile): Promise<void> {
 
     await Bun.write(path, file)
     
-    console.log('File backed-up successfully.')
+    console.info('File backed-up successfully.')
 }
 
 main()
-    .then(() => console.log('Operation completed successfully.'))
+    .then(() => console.info('Operation completed successfully.'))
     .catch(err => console.error('An error occurred:', err))


### PR DESCRIPTION
```bash
Editing file : /Users/loic/Library/Application Support/SynologyDrive/SynologyDrive.app/Contents/Resources/conf/blacklist.filter
File backed-up successfully.
An error occurred: 87 |         })
88 |     }
89 | 
90 |     // We save the file
91 |     const updatedConfig = ini.stringify(config)
92 |     await Bun.write(path, updatedConfig)
                   ^
EPERM: operation not permitted, open '/Users/loic/Library/Application Support/SynologyDrive/SynologyDrive.app/Contents/Resources/conf/blacklist.filter'
    path: "/Users/loic/Library/Application Support/SynologyDrive/SynologyDrive.app/Contents/Resources/conf/blacklist.filter",
 syscall: "open",
   errno: -1,
    code: "EPERM"

      at <anonymous> (/Users/loic/CloudStation/Dev/synology-drive-ignore-nm/index.ts:92:15)
```